### PR TITLE
Fixed .summary() IndexError

### DIFF
--- a/plugins/mipsrop/mipsrop.py
+++ b/plugins/mipsrop/mipsrop.py
@@ -549,7 +549,7 @@ class MIPSROPFinder(object):
 				while ea <= end_ea:
 					summary.append(idc.GetDisasm(ea))
 					mnem = idc.GetMnem(ea)
-					if mnem[0].lower() in ['j', 'b']:
+					if len(mnem) > 0 and mnem[0].lower() in ['j', 'b']:
 						summary.append(idc.GetDisasm(ea+self.INSIZE))
 						break
 


### PR DESCRIPTION
Fixes the following observed in IDA 6.4.130111:

Python>mipsrop.summary()
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/ida/bin/plugins/mipsrop.py", line 552, in summary
    if mnem[0].lower() in ['j', 'b']:
IndexError: string index out of range
