### PR TITLE
Added the address of the xrefs to the printout

### DIFF
--- a/plugins/localxrefs/localxrefs.py
+++ b/plugins/localxrefs/localxrefs.py
@@ -105,6 +105,7 @@ class LocalXrefs(object):
 
 				self.xrefs[ea] = {
 					'offset' 	: idc.GetFuncOffset(ea),
+					'ea'		: ea,
 					'mnem'	 	: mnem,
 					'type'		: optype,
 					'direction'	: direction,
@@ -171,9 +172,9 @@ class localizedxrefs_t(idaapi.plugin_t):
 				info = r.xrefs[ea]
 	
 				if not fmt:
-					fmt = "%%s   %%s   %%-%ds   %%s\n" % (len(info['offset']) + 15)
+					fmt = "%%s   %%s   0x%%08X %%-%ds   %%s\n" % (len(info['offset']) + 15)
 
-				idaapi.msg(fmt % (info['direction'], info['type'], info['offset'], info['text']))
+				idaapi.msg(fmt % (info['direction'], info['type'], info['ea'], info['offset'], info['text']))
 	
 			idaapi.msg(self.DELIM)
 


### PR DESCRIPTION
Since double-clicking names like `BlaBla(x,x,x)` in the output window does not jump to the clicked location, the address has been added to the printout to allow easy navigation.