### PR TITLE
Fix for IDA 6.8

### DIFF
--- a/plugins/leafblower/leafblower.py
+++ b/plugins/leafblower/leafblower.py
@@ -508,7 +508,7 @@ class leaf_blower_t(idaapi.plugin_t):
         idaapi.del_menu_item(self.stdio_context_menu)
         return None
 
-    def run(self):
+    def run(self, arg):
         pass
 
     def LeafFromMenu(self, arg):


### PR DESCRIPTION
This plugin doesn't seem to run on IDA 6.8, it throws an error saying that plugin.run() should have two arguments. This fixes it. I don't have an earlier version of IDA available to test it, so I don't know if the fix is backwards compatible... (probably not)