### PR TITLE
added trailing slash to menu_tab string as fix for missing menu entries

### DIFF
--- a/plugins/rizzo/rizzo.py
+++ b/plugins/rizzo/rizzo.py
@@ -500,7 +500,7 @@ class RizzoPlugin(idaapi.plugin_t):
     menu_name = "Rizzo signature file..."
     produce_tooltip = "Produce rizzo signature file."
     load_tooltip = "Load rizzo signature file."
-    menu_tab = 'File'
+    menu_tab = 'File/'
     menu_context = []
 
     def init(self):


### PR DESCRIPTION
**Rizzo**, for IDA **7.2**
`menu_tab = 'File'` was missing the trailing slash, yielding a menu search for `FileProduce file/` and `FileLoad file/` which fails to attach the appropriate rizzo menu options.

Trailing slash added to resolve issue.