### PR TITLE
Add dummy arg parameter for funcprofiler plugin_t.run()

### DIFF
--- a/plugins/funcprofiler/funcprofiler.py
+++ b/plugins/funcprofiler/funcprofiler.py
@@ -350,7 +350,7 @@ class IDAFunctionProfilerPlugin(idaapi.plugin_t):
                 idaapi.del_menu_item(context)
         return None
 
-    def run(self):
+    def run(self, arg):
         pass
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18397468/147631088-2cd5173c-3068-4640-a453-810e6b80d6bc.png)

Function Profiler run will fail due to lack of dummy arg in plugin_t.run