### PR TITLE
Add NIOS2 architecture to leafblower, fix run() declaration for #51

### DIFF
--- a/plugins/leafblower/leafblower.py
+++ b/plugins/leafblower/leafblower.py
@@ -145,7 +145,11 @@ class ArchitectureSpecific(object):
                              delay=1, size=4),
         ArchitectureSettings(name="ARM",
                              argv=['R0', 'R1', 'R2', 'R3'],
+                             delay=0, size=4),
+        ArchitectureSettings(name="NIOS2",
+                             argv=['r4', 'r5', 'r6', 'r7'],
                              delay=0, size=4)
+
     ]
 
     def __init__(self):
@@ -642,7 +646,8 @@ class leaf_blower_t(idaapi.plugin_t):
                 idaapi.del_menu_item(context)
         return None
 
-    def run(self):
+    def run(self, arg):
+        print(arg)
         pass
 
 


### PR DESCRIPTION
Hello, I have added support for Altera NIOS2 CPU architecture into leafblower. This works thanks to the great work of Positive Research, who developed the NIOS2 CPU plugin which was once hosted [here](https://github.com/ptresearch). The link seems to have very recently gone dead, but I cloned the repository a while back ([here](https://github.com/mzpqnxow/nios2))

I also included the small change to fix #51 

Thanks for making these publicly available, I've got a ton of use out of them